### PR TITLE
Automate footer year update 

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,8 +448,8 @@
             </div>
             
             <div class="border-t border-gray-800 pt-8 text-center text-gray-400">
-                <p>&copy; 2024 EcoPulse. Built with ❤️ for environmental awareness.</p>
-                <p class="mt-2 text-sm">Hackathon 2024 • Environmental Data Initiative</p>
+                <p>&copy; <span id="year"></span> EcoPulse. Built with ❤️ for environmental awareness.</p>
+                <p class="mt-2 text-sm">Hackathon • Environmental Data Initiative</p>
             </div>
         </div>
     </footer>
@@ -463,6 +463,10 @@
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="js/main.js" defer></script>
+    <script>
+      // Auto-update year in footer
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
     <script>// Scroll to Top Functionality
 ;(() => {
   const scrollButton = document.getElementById("scroll-to-top")


### PR DESCRIPTION
##  Footer Year Automation Update

### Changes Made
1. **Updated Footer HTML**
   - Replaced:
     ```html
     <p>&copy; 2024 EcoPulse...</p>
     ```
     with:
     ```html
     <p>&copy; <span id="year"></span> EcoPulse...</p>
     ```
   - Added a dynamic placeholder to display the current year.

2. **Added Auto-Update Script**
   - Introduced a small JavaScript snippet that runs on page load.
   - Uses `new Date().getFullYear()` to fetch the current year.
   - Automatically injects the year into the `<span id="year">` element.

3. **Removed Hardcoded Year References**
   - Removed the fixed `2024` year from the footer.
   - Updated **“Hackathon 2024”** to **“Hackathon”** for broader, long-term relevance.

### Benefits
- ✅ **No Manual Updates Needed** – Automatically shows 2026 today and updates to 2027 on Jan 1, 2027.
- ✅ **Future-Proof** – Works seamlessly every year without code changes.
- ✅ **Clean & Simple** – Minimal JavaScript, no external dependencies.

fixes #8 
<img width="997" height="127" alt="image" src="https://github.com/user-attachments/assets/104fe9c0-b3dc-472a-8acf-3377b5910a1c" />
