### PR TITLE
Refactor auto-assign workflow for better error handling

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -9,9 +9,8 @@ permissions:
 
 jobs:
   assign:
-    permissions:
-      issues: write
     runs-on: ubuntu-latest
+
     steps:
       - name: Assign issue to creator
         uses: actions/github-script@v7
@@ -21,14 +20,18 @@ jobs:
               const issue = context.payload.issue;
               const creator = issue.user.login;
 
-            try {
               await github.rest.issues.addAssignees({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 assignees: [creator],
               });
-              console.log(`Successfully assigned issue #${issue.number} to ${creator}`);
+
+              console.log(
+                `Successfully assigned issue #${issue.number} to ${creator}`
+              );
             } catch (error) {
-              console.warn(`Could not auto-assign issue #${issue.number}: ${error.message}`);
+              core.setFailed(
+                `Auto-assign failed for issue #${context.payload.issue?.number}: ${error.message}`
+              );
             }


### PR DESCRIPTION
This workflow automatically assigns newly opened issues to the issue creator.
It helps maintainers reduce manual work and ensures faster ownership and accountability for reported issues.

🚀 How it works

Triggers when a new issue is opened
Fetches the issue creator’s GitHub username
Automatically assigns the issue to the creator
Fails gracefully with a clear error message if assignment is not possible

🔐 Permissions

Requires issues: write permission to assign users to issues

✅ Benefits

Saves maintainer time
Encourages contributors to take ownership
Keeps issue management clean and organized
Works seamlessly with public and private repositories