### PR TITLE
Add target audience section to README for better contributor guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ EcoPulse transforms complex datasets into immersive 3D stories.
 
 ---
 
+## 🎯 Who Is This Project For?
+
+- Students learning Three.js and WebGL
+- Hackathon participants building climate-tech apps
+- Beginners in open-source contribution
+- Developers interested in data visualization
+
+
 ## 🛠️ Tech Stack
 | Category | Technology | Usage |
 | :--- | :--- | :--- |


### PR DESCRIPTION
This PR adds a "Who Is This Project For?" section to the README to clearly describe the intended audience and contributors of EcoPulse.

It helps:
- New contributors quickly understand if the project matches their skill level
- Hackathon participants and students identify learning opportunities
- Improve overall documentation clarity
