### PR TITLE
fix: remove leftover merge markers from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,6 @@
         rel="stylesheet">
 
     <script src="https://cdn.tailwindcss.com"></script>
- feat/live-countdown-sticky-cta
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
 
@@ -35,8 +34,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script> 
 
     <link rel="stylesheet" href="css/styles.css">
- feat/live-countdown-sticky-cta
-
     
 
 
@@ -82,7 +79,6 @@
 </div>
 
 <body class="bg-gray-900 text-white">
-feat/live-countdown-sticky-cta
 
     <!-- Skip to Content Link for Accessibility -->
     
@@ -109,7 +105,7 @@ feat/live-countdown-sticky-cta
                 <div class="w-10 h-10 bg-gradient-to-r from-eco-blue to-eco-green rounded-lg flex items-center justify-center">
                     <span class="text-white font-bold text-xl">E</span>
                 </div>
- feat/live-countdown-sticky-cta
+ 
                 <span class="text-2xl font-bold gradient-text">EcoPulse</span>
             </a>
 
@@ -229,7 +225,7 @@ feat/live-countdown-sticky-cta
             </div>
 
         </section>
- feat/live-countdown-sticky-cta
+ 
 
 
 
@@ -1104,8 +1100,8 @@ feat/live-countdown-sticky-cta
         🚀 Register Now
     </a>
 
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-feat/live-countdown-sticky-cta
 
     <!-- ✅ MODULE SCRIPT -->
     <script type="module" src="js/script.js"></script>


### PR DESCRIPTION
Removed stray branch name text that was accidentally left in the HTML after a merge, which was rendering on the page.
