### PR TITLE
Fix AQI category thresholds in slider logic

### DIFF
--- a/js/air.js
+++ b/js/air.js
@@ -42,17 +42,17 @@ document.addEventListener('DOMContentLoaded', () => {
             let colorClass = "text-eco-green";
             let statusClass = "aqi-status-good";
 
-            if (value >= 50 && value < 100) {
+            if (value > 50 && value <= 100) {
                 level = 'Moderate';
                 colorClass = "text-yellow-400";
                 statusClass = "aqi-status-moderate";
             }
-            else if (value >= 100 && value < 200) {
+            else if (value > 100 && value <= 200) {
                 level = 'Unhealthy';
                 colorClass = "text-eco-orange";
                 statusClass = "aqi-status-unhealthy";
             }
-            else if (value >= 200) {
+            else if (value > 200) {
                 level = 'Hazardous';
                 colorClass = "text-eco-purple";
                 statusClass = "aqi-status-hazardous";


### PR DESCRIPTION
This PR updates the AQI slider category logic to follow standard AQI ranges:

- 0–50: Good
- 51–100: Moderate
- 101–200: Unhealthy
- 201+: Hazardous

This ensures that the displayed air quality category matches accepted AQI definitions
and provides more accurate feedback to users.
