### PR TITLE
Improve sparkline rendering by syncing canvas size with CSS

### DIFF
--- a/js/air.js
+++ b/js/air.js
@@ -11,6 +11,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // FUNCTION TO DRAW THE SPARKLINE
     function drawSparkline(canvasId, dataPoints) {
         const canvas = document.getElementById(canvasId);
+        canvas.width = canvas.offsetWidth;
+        canvas.height = canvas.offsetHeight;
+
         if (!canvas) return;
         const ctx = canvas.getContext('2d');
         const width = canvas.width;


### PR DESCRIPTION
This PR improves the sparkline graph rendering by matching the canvas resolution
with its CSS display size before drawing.

This prevents blurry graphs on different screen sizes and ensures sharper
visualization of AQI trends without changing existing behavior.
