### PR TITLE
Fix resize event listener cleanup in light pollution scene

### DIFF
--- a/js/light-3d.js
+++ b/js/light-3d.js
@@ -13,7 +13,8 @@ class LightPollutionScene {
         this.cityLights = [];
         this.stars = [];
         this.milkyWay = null;
-        
+        this.handleResize = this.onWindowResize.bind(this);
+
         this.init();
     }
     
@@ -64,7 +65,8 @@ class LightPollutionScene {
             this.createMilkyWay();
             
             // Handle window resize
-            window.addEventListener('resize', () => this.onWindowResize());
+           window.addEventListener('resize', this.handleResize);
+
             
             // Set initialized flag
             this.isInitialized = true;
@@ -301,8 +303,8 @@ class LightPollutionScene {
         }
         
         // Remove event listeners
-        window.removeEventListener('resize', this.onWindowResize);
-        
+       window.removeEventListener('resize', this.handleResize);
+
         // Clear scene
         if (this.scene) {
             while(this.scene.children.length > 0) { 


### PR DESCRIPTION
This PR fixes the resize event listener handling in the LightPollutionScene.

Previously, the resize listener was added using an anonymous function but removed
using a different reference, which prevented proper cleanup and could lead to
memory leaks when the scene is recreated.

The listener is now bound once and correctly added and removed during the
scene lifecycle.
