### PR TITLE
Fix CODE_OF_CONDUCT.md typo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,6 @@
 
 ## 📄 `CODE_OF_CONDUCT.md`
 
-```md
 # Code of Conduct
 
 ## Our Commitment


### PR DESCRIPTION
## Pull Request

### Description

This PR fixes a minor typo in `CODE_OF_CONDUCT.md` by removing an unnecessary Markdown code fence.

### Type of Change

* [x] Documentation update

### Changes Made

* Removed redundant ```md code block formatting from `CODE_OF_CONDUCT.md`

### Motivation and Context

The extra Markdown fence was unnecessary and affected the readability of the document.
This change ensures the Code of Conduct renders correctly and remains clean and consistent.

### Testing

* Verified correct rendering of `CODE_OF_CONDUCT.md` on GitHub

### Breaking Changes

None.

### Additional Notes

Documentation-only change; no functional impact.